### PR TITLE
Change np.float to np.float32

### DIFF
--- a/inference/interact/fbrs/inference/predictors/brs_functors.py
+++ b/inference/interact/fbrs/inference/predictors/brs_functors.py
@@ -72,7 +72,7 @@ class BaseOptimizer:
         self._last_mask = current_mask
 
         loss.backward()
-        f_grad = opt_params.grad.cpu().numpy().ravel().astype(np.float)
+        f_grad = opt_params.grad.cpu().numpy().ravel().astype(np.float32)
 
         return [f_val, f_grad]
 


### PR DESCRIPTION
It seems most, if not all other np.float has been changed to np.float32. This np.float caused error when running the interactive demo with python 3.10, numpy 1.24.2