### PR TITLE
Added support for MPS Apple Silicon and quality of life improvements to the GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ output/
 .vscode/
 workspace/
 run*.sh
+.DS_Store
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -36,7 +36,7 @@ python interactive_demo.py --video [path to the video] --num_objects 4
 
 * Use the slider to change the current frame. "Play Video" automatically progresses the video.
 * Select interaction type: "scribble", "click", or "free". Both scribble and "free" (free-hand drawing) modify an existing mask. Using "click" on an existing object mask (i.e., a mask from propagation or other interaction methods) will reset the mask. This is because f-BRS does not take an existing mask as input.
-* Select the target object using the number keys. "1" corresponds to the first object, etc. You need to specify the maximum number of objects when you start the program through the command line.
+* Select the target object using the number keys or the object dial. "1" corresponds to the first object, etc. You need to specify the maximum number of objects when you start the program through the command line. On Mac, you can use ctrl+number to select the object.
 * Use propagate forward/backward to let XMem do the job. Pause when correction is needed. It will only automatically stops when it hits the end of the video.
 * Make sure all objects are correctly labeled before propagating. The program doesn't care which object you have interacted with -- it treats everything as user-provided inputs. Not labelling an object implicitly means that it is part of the background.
 * The memory bank might be "polluted" by bad memory frames. Feel free to hit clear memory to erase that. Propagation runs faster with a small memory bank.
@@ -53,6 +53,6 @@ python interactive_demo.py --video [path to the video] --num_objects 4
    - Make sure you specified `--num_objects`. We ignore object IDs that exceed `num_objects`.
 2. The GUI feels slow!
    - The GUI needs to read/write images and masks on-the-go. Ideally this can be implemented with multiple threads with look-ahead but I didn't. The overheads will be smaller if you place the `workspace` on a SSD. You can also use a ram disk. `eval.py` will almost certainly be faster.
-   - It takes more time to process more objects. This depends on `num_objects`, but not the actual number of objects that the user has annotated. *This does not mean that running time is directly proportional to the number of objects. There is significant shared computation.*
+   - It takes more time to process more objects. This depends on `num_objects`, not the actual number of objects that the user has annotated. *This does not mean that running time is directly proportional to the number of objects. There is significant shared computation.*
 3. Can I run this on a remote server?
    - X11 forwarding should be possible. I have not tried this and would love to know if it works for you.

--- a/eval.py
+++ b/eval.py
@@ -218,7 +218,7 @@ for vid_reader in progressbar(meta_loader, max_value=len(meta_dataset), redirect
                 prob = torch.flip(prob, dims=[-1])
 
             # Probability mask -> index mask
-            out_mask = torch.argmax(prob, dim=0)
+            out_mask = torch.max(prob, dim=0).indices
             out_mask = (out_mask.detach().cpu().numpy()).astype(np.uint8)
 
             if args.save_scores:

--- a/inference/interact/fbrs/controller.py
+++ b/inference/interact/fbrs/controller.py
@@ -1,4 +1,5 @@
 import torch
+from torch import mps
 
 from ..fbrs.inference import clicker
 from ..fbrs.inference.predictors import get_predictor
@@ -35,7 +36,10 @@ class InteractiveController:
         click = clicker.Click(is_positive=is_positive, coords=(y, x))
         self.clicker.add_click(click)
         pred = self.predictor.get_prediction(self.clicker)
-        torch.cuda.empty_cache()
+        if self.device.type == 'cuda':
+            torch.cuda.empty_cache()
+        elif self.device.type == 'mps':
+            mps.empty_cache()
 
         if self.probs_history:
             self.probs_history.append((self.probs_history[-1][0], pred))

--- a/inference/interact/fbrs/controller.py
+++ b/inference/interact/fbrs/controller.py
@@ -1,5 +1,8 @@
 import torch
-from torch import mps
+try:
+    from torch import mps
+except:
+    pass
 
 from ..fbrs.inference import clicker
 from ..fbrs.inference.predictors import get_predictor

--- a/inference/interact/gui.py
+++ b/inference/interact/gui.py
@@ -21,7 +21,10 @@ os.environ.pop("QT_QPA_PLATFORM_PLUGIN_PATH")
 
 import numpy as np
 import torch
-from torch import mps
+try:
+    from torch import mps
+except:
+    print('torch.MPS not available.')
 
 from PyQt6.QtWidgets import (QWidget, QApplication, QComboBox, QCheckBox,
     QHBoxLayout, QLabel, QPushButton, QTextEdit, QSpinBox, QFileDialog,

--- a/inference/interact/gui.py
+++ b/inference/interact/gui.py
@@ -240,6 +240,18 @@ class App(QWidget):
         interact_subbox.addLayout(interact_botbox)
         navi.addLayout(interact_subbox)
 
+        index = interact_topbox.count()
+        while(index > 0):
+            index -=1
+            myWidget = interact_topbox.itemAt(index).widget()
+            myWidget.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        index = interact_botbox.count()
+        while(index > 0):
+            index -=1
+            myWidget = interact_botbox.itemAt(index).widget()
+            myWidget.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+
+
         navi.addStretch(1)
 
         navi.addStretch(1)

--- a/inference/interact/gui.py
+++ b/inference/interact/gui.py
@@ -94,12 +94,13 @@ class App(QWidget):
         self.lcd.setText('{: 4d} / {: 4d}'.format(0, self.num_frames-1))
 
         # Current Mask LCD
-        self.mask_lcd = QTextEdit()
-        self.mask_lcd.setReadOnly(False)
-        self.mask_lcd.setMaximumHeight(28)
-        self.mask_lcd.setMaximumWidth(56)
-        self.mask_lcd.setText('1')
-        self.mask_lcd.textChanged.connect(self.on_mask_lcd_change)
+        self.object_dial = QSpinBox()
+        self.object_dial.setReadOnly(False)
+        self.object_dial.setMaximumHeight(28)
+        self.object_dial.setMaximumWidth(56)
+        self.object_dial.setMinimum(1)
+        self.object_dial.setMaximum(self.num_objects)
+        self.object_dial.editingFinished.connect(self.on_object_dial_change)
 
         # timeline slider
         self.tl_slider = QSlider(Qt.Orientation.Horizontal)
@@ -232,7 +233,7 @@ class App(QWidget):
         interact_topbox.addWidget(self.radio_free)
         interact_topbox.addWidget(self.reset_button)
         interact_botbox.addWidget(QLabel('Current Object ID:'))
-        interact_botbox.addWidget(self.mask_lcd)
+        interact_botbox.addWidget(self.object_dial)
         interact_botbox.addWidget(self.brush_label)
         interact_botbox.addWidget(self.brush_slider)
         interact_subbox.addLayout(interact_topbox)
@@ -690,12 +691,9 @@ class App(QWidget):
         else:
             self.console_push_text(f'No visualization images found in {image_folder}')
 
-    def on_mask_lcd_change(self):
-        mask_num = self.mask_lcd.toPlainText()
-        if mask_num.isdigit() and 1 <= int(mask_num) and int(mask_num) <= self.num_objects+1:
-            self.hit_number_key(int(mask_num))
-        else:
-            self.console_push_text(f'Error {mask_num} is not a valid mask number')
+    def on_object_dial_change(self):
+        object_id = self.object_dial.value()
+        self.hit_number_key(object_id)
 
     def on_reset_mask(self):
         self.current_mask.fill(0)
@@ -729,7 +727,7 @@ class App(QWidget):
         if number == self.current_object:
             return
         self.current_object = number
-        self.mask_lcd.setPlainText(str(number))
+        self.object_dial.setValue(number)
         if self.fbrs_controller is not None:
             self.fbrs_controller.unanchor()
         self.console_push_text(f'Current object changed to {number}.')

--- a/inference/interact/gui_utils.py
+++ b/inference/interact/gui_utils.py
@@ -1,5 +1,5 @@
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import (QHBoxLayout, QLabel, QSpinBox, QVBoxLayout, QProgressBar)
+from PyQt6.QtWidgets import (QBoxLayout, QHBoxLayout, QLabel, QSpinBox, QVBoxLayout, QProgressBar)
 
 
 def create_parameter_box(min_val, max_val, text, step=1, callback=None):
@@ -38,3 +38,9 @@ def create_gauge(text):
     layout.addWidget(gauge)
 
     return gauge, layout
+
+
+def apply_to_all_children_widget(layout, func):
+    # deliberately non-recursive
+    for i in range(layout.count()):
+        func(layout.itemAt(i).widget())

--- a/inference/interact/gui_utils.py
+++ b/inference/interact/gui_utils.py
@@ -1,5 +1,5 @@
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import (QHBoxLayout, QLabel, QSpinBox, QVBoxLayout, QProgressBar)
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (QHBoxLayout, QLabel, QSpinBox, QVBoxLayout, QProgressBar)
 
 
 def create_parameter_box(min_val, max_val, text, step=1, callback=None):
@@ -10,12 +10,12 @@ def create_parameter_box(min_val, max_val, text, step=1, callback=None):
     dial.setMaximumWidth(150)
     dial.setMinimum(min_val)
     dial.setMaximum(max_val)
-    dial.setAlignment(Qt.AlignRight)
+    dial.setAlignment(Qt.AlignmentFlag.AlignRight)
     dial.setSingleStep(step)
     dial.valueChanged.connect(callback)
 
     label = QLabel(text)
-    label.setAlignment(Qt.AlignRight)
+    label.setAlignment(Qt.AlignmentFlag.AlignRight)
 
     layout.addWidget(label)
     layout.addWidget(dial)
@@ -29,10 +29,10 @@ def create_gauge(text):
     gauge = QProgressBar()
     gauge.setMaximumHeight(28)
     gauge.setMaximumWidth(200)
-    gauge.setAlignment(Qt.AlignCenter)
+    gauge.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
     label = QLabel(text)
-    label.setAlignment(Qt.AlignRight)
+    label.setAlignment(Qt.AlignmentFlag.AlignRight)
 
     layout.addWidget(label)
     layout.addWidget(gauge)

--- a/inference/interact/interaction.py
+++ b/inference/interact/interaction.py
@@ -125,7 +125,7 @@ class FreeInteraction(Interaction):
         self.curr_path = [[] for _ in range(self.K + 1)]
 
     def predict(self):
-        self.out_prob = index_numpy_to_one_hot_torch(self.drawn_map, self.K+1).cuda()
+        self.out_prob = index_numpy_to_one_hot_torch(self.drawn_map, self.K+1)
         # self.out_prob = torch.from_numpy(self.drawn_map).float().cuda()
         # self.out_prob, _ = pad_divide_by(self.out_prob, 16, self.out_prob.shape[-2:])
         # self.out_prob = aggregate_sbg(self.out_prob, keep_bg=True)

--- a/inference/interact/interactive_utils.py
+++ b/inference/interact/interactive_utils.py
@@ -15,7 +15,7 @@ def image_to_torch(frame: np.ndarray, device='cuda'):
     return frame_norm, frame
 
 def torch_prob_to_numpy_mask(prob):
-    mask = torch.argmax(prob, dim=0)
+    mask = torch.max(prob, dim=0).indices
     mask = mask.cpu().numpy().astype(np.uint8)
     return mask
 
@@ -26,16 +26,21 @@ def index_numpy_to_one_hot_torch(mask, num_classes):
 """
 Some constants fro visualization
 """
+if torch.cuda.is_available():
+    device = torch.device("cuda")
+elif torch.backends.mps.is_available():
+    device = torch.device("mps")
+else:
+    device = torch.device("cpu")
+
 color_map_np = np.frombuffer(davis_palette, dtype=np.uint8).reshape(-1, 3).copy()
 # scales for better visualization
 color_map_np = (color_map_np.astype(np.float32)*1.5).clip(0, 255).astype(np.uint8)
 color_map = color_map_np.tolist()
-if torch.cuda.is_available():
-    color_map_torch = torch.from_numpy(color_map_np).cuda() / 255
+color_map_torch = torch.from_numpy(color_map_np).to(device) / 255
 
 grayscale_weights = np.array([[0.3,0.59,0.11]]).astype(np.float32)
-if torch.cuda.is_available():
-    grayscale_weights_torch = torch.from_numpy(grayscale_weights).cuda().unsqueeze(0)
+grayscale_weights_torch = torch.from_numpy(grayscale_weights).to(device).unsqueeze(0)
 
 def get_visualization(mode, image, mask, layer, target_object):
     if mode == 'fade':
@@ -112,7 +117,7 @@ def overlay_davis_torch(image, mask, alpha=0.5, fade=False):
     # Changes the image in-place to avoid copying
     image = image.permute(1, 2, 0)
     im_overlay = image
-    mask = torch.argmax(mask, dim=0)
+    mask = torch.max(mask, dim=0).indices
 
     colored_mask = color_map_torch[mask]
     foreground = image*alpha + (1-alpha)*colored_mask

--- a/inference/interact/interactive_utils.py
+++ b/inference/interact/interactive_utils.py
@@ -26,11 +26,14 @@ def index_numpy_to_one_hot_torch(mask, num_classes):
 """
 Some constants fro visualization
 """
-if torch.cuda.is_available():
-    device = torch.device("cuda")
-elif torch.backends.mps.is_available():
-    device = torch.device("mps")
-else:
+try:
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
+except:
     device = torch.device("cpu")
 
 color_map_np = np.frombuffer(davis_palette, dtype=np.uint8).reshape(-1, 3).copy()

--- a/inference/interact/s2m_controller.py
+++ b/inference/interact/s2m_controller.py
@@ -19,6 +19,7 @@ class S2MController:
         self.device = device
 
     def interact(self, image, prev_mask, scr_mask):
+        print(self.device)
         image = image.to(self.device, non_blocking=True)
         prev_mask = prev_mask.unsqueeze(0)
 

--- a/interactive_demo.py
+++ b/interactive_demo.py
@@ -3,6 +3,7 @@ A simple user interface for XMem
 """
 
 import os
+from os import path
 # fix for Windows
 if 'QT_QPA_PLATFORM_PLUGIN_PATH' not in os.environ:
     os.environ['QT_QPA_PLATFORM_PLUGIN_PATH'] = ''
@@ -17,15 +18,21 @@ from inference.interact.s2m_controller import S2MController
 from inference.interact.fbrs_controller import FBRSController
 from inference.interact.s2m.s2m_network import deeplabv3plus_resnet50 as S2M
 
-from PyQt5.QtWidgets import QApplication
+from PyQt6.QtWidgets import QApplication
 from inference.interact.gui import App
 from inference.interact.resource_manager import ResourceManager
+from contextlib import nullcontext
 
 torch.set_grad_enabled(False)
 
+if torch.cuda.is_available():
+    device = torch.device("cuda")
+elif torch.backends.mps.is_available():
+    device = torch.device("mps")
+else:
+    device = torch.device("cpu")
 
 if __name__ == '__main__':
-    
     # Arguments parsing
     parser = ArgumentParser()
     parser.add_argument('--model', default='./saves/XMem.pth')
@@ -64,26 +71,37 @@ if __name__ == '__main__':
             help='Resize the shorter side to this size. -1 to use original resolution. ')
     args = parser.parse_args()
 
+    # create temporary workspace if not specified
     config = vars(args)
     config['enable_long_term'] = True
     config['enable_long_term_count_usage'] = True
 
-    with torch.cuda.amp.autocast(enabled=not args.no_amp):
+    if config["workspace"] is None:
+        if config["images"] is not None:
+            basename = path.basename(config["images"])
+        elif config["video"] is not None:
+            basename = path.basename(config["video"])[:-4]
+        else:
+            raise NotImplementedError(
+                'Either images, video, or workspace has to be specified')
 
+        config["workspace"] = path.join('./workspace', basename)
+
+    with torch.cuda.amp.autocast(enabled=not args.no_amp) if device.type == 'cuda' else nullcontext():
         # Load our checkpoint
-        network = XMem(config, args.model).cuda().eval()
+        network = XMem(config, args.model, map_location=device).to(device).eval()
 
         # Loads the S2M model
         if args.s2m_model is not None:
-            s2m_saved = torch.load(args.s2m_model)
-            s2m_model = S2M().cuda().eval()
+            s2m_saved = torch.load(args.s2m_model, map_location=device)
+            s2m_model = S2M().to(device).eval()
             s2m_model.load_state_dict(s2m_saved)
         else:
             s2m_model = None
 
-        s2m_controller = S2MController(s2m_model, args.num_objects, ignore_class=255)
+        s2m_controller = S2MController(s2m_model, args.num_objects, ignore_class=255, device=device)
         if args.fbrs_model is not None:
-            fbrs_controller = FBRSController(args.fbrs_model)
+            fbrs_controller = FBRSController(args.fbrs_model, device=device)
         else:
             fbrs_controller = None
 
@@ -91,5 +109,5 @@ if __name__ == '__main__':
         resource_manager = ResourceManager(config)
 
         app = QApplication(sys.argv)
-        ex = App(network, resource_manager, s2m_controller, fbrs_controller, config)
-        sys.exit(app.exec_())
+        ex = App(network, resource_manager, s2m_controller, fbrs_controller, config, device)
+        sys.exit(app.exec())

--- a/requirements_demo.txt
+++ b/requirements_demo.txt
@@ -1,3 +1,3 @@
-PyQt5
+PyQt6
 Cython
 scipy


### PR DESCRIPTION
With increased MPS support from PyTorch, this feature will be necessary for users to run XMem on-device.
Provided is a brief summary of the changes:
- Updated code to use PyQt6
- Added checks for MPS instead of just CUDA
- Added code to correctly start the timeout sequence for the video player
- Tracking memory usage is not supported by PyTorch, so I patched a temporary fix where I just return their currently used memory, until PyTorch updates their MPS support
- Changed the shortcuts to be Cmd/Cntrl + (1 - N) and I also added a new widget to the GUI where users could manually select the object they wanted to select/edit. The keys 1 through N did not work if users were on Mac because of way Qt handles Mac shortcuts. Along with this, if users wanted to select more than 9 objects they previously could not.
- Added widget to export video of overlayed frames.

A few remaining issues include:
- Shortcuts such as the arrow keys are not working on Mac
- Accessing total memory is not supported by PyTorch for mps
- The eval.py file among others has not been fully updated to support mps. This pull request only includes code related to the GUI